### PR TITLE
Fix for BRJS 0.14 manifest file errors

### DIFF
--- a/src/main/java/org/bladerunnerjs/contrib/contentplugin/appcache/AppcacheManifestBuilder.java
+++ b/src/main/java/org/bladerunnerjs/contrib/contentplugin/appcache/AppcacheManifestBuilder.java
@@ -121,9 +121,16 @@ public class AppcacheManifestBuilder
 			String path = app.createBundleRequest(requestMode, contentPath, brjsVersion);
 			// Spaces need to be URL encoded or the manifest doesnt load the files correctly
 			path = path.replaceAll(" ", "%20");
-			// Path begins with .. as paths are relative to the manifest file,
-			// and the manifest is in the "appcache/" directory
-			cacheFiles.append("../" + path + "\n");
+
+            // Path begins with .. as paths are relative to the manifest file,
+            // and the manifest is in the "appcache/" directory
+            if(!path.startsWith("/")) {
+                path = "../" + path;
+            } else {
+                path = ".." + path;
+            }
+
+            cacheFiles.append(path + "\n");
 		}
 		return cacheFiles.toString();
 	}

--- a/src/test/java/org/bladerunnerjs/contrib/contentplugin/appcache/tests/AppcacheContentPluginDevTests.java
+++ b/src/test/java/org/bladerunnerjs/contrib/contentplugin/appcache/tests/AppcacheContentPluginDevTests.java
@@ -2,6 +2,7 @@ package org.bladerunnerjs.contrib.contentplugin.appcache.tests;
 
 import org.bladerunnerjs.contrib.contentplugin.appcache.mocks.MockCompositeContentPlugin;
 import org.bladerunnerjs.contrib.contentplugin.appcache.mocks.MockContentPlugin;
+import org.bladerunnerjs.memoization.MemoizedFile;
 import org.bladerunnerjs.model.App;
 import org.bladerunnerjs.model.Aspect;
 import org.bladerunnerjs.testing.specutility.engine.SpecTest;
@@ -13,6 +14,7 @@ public class AppcacheContentPluginDevTests extends SpecTest
 {
 	private App app;
 	private Aspect aspect;
+    private MemoizedFile unbundledResources;
 	private StringBuffer pageResponse = new StringBuffer();
 
 	@Before
@@ -24,6 +26,7 @@ public class AppcacheContentPluginDevTests extends SpecTest
 				.and(brjs).hasBeenCreated();
 		app = brjs.app("appcacheApp");
 		aspect = app.aspect("default");
+        unbundledResources = aspect.file("unbundled-resources");
 	}
 
 	@After
@@ -172,5 +175,16 @@ public class AppcacheContentPluginDevTests extends SpecTest
 		when(app).requestReceived("appcache/dev.appcache", pageResponse);
         then(aspect).containsTransientNodeProperty("appcache", "version", "1.2.3-dev");
 	}
+
+    @Test
+    public void testUnbundledResourcesFilesAreListedCorrectly() throws Exception
+    {
+        given(app).hasBeenCreated().and(aspect).hasBeenCreated()
+                .and(aspect).containsFileWithContents("conf/appcache.conf", "devVersion: 1234")
+                .and(unbundledResources).containsFile("some-file");
+        when(app).requestReceived("appcache/dev.appcache", pageResponse);
+        then(pageResponse).containsText("../unbundled-resources/some-file")
+                .and(pageResponse).containsText("../v/dev/unbundled-resources/some-file");
+    }
 
 }


### PR DESCRIPTION
Fixing an issue with manifest paths being formatted badly when the path returned by BRJS starts with a / (commonly found when dealing with unbundled-resources). This was caused due to the plugin assuming all paths were relative and prefixing them with a ../
This issue would cause appcache errors in the browser and prevent things from loading correctly.
